### PR TITLE
Fix some scope issues

### DIFF
--- a/src/finalize.js
+++ b/src/finalize.js
@@ -5,6 +5,6 @@
  */
 (function(scope) {
   if (!scope.keep) {
-    delete window.PointerEventShim;
+    window.PointerEventShim = undefined;
   }
 })(window.PointerEventShim);

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -35,4 +35,5 @@
     }
     return inSink;
   };
+  window.PointerEventShim = scope;
 })(window.PointerEventShim);


### PR DESCRIPTION
Finalize sets window object to undefined, not `delete`ing it
Bind scope to window.PointerEventShim correctly
