### PR TITLE
Only watch document and real shadow roots

### DIFF
--- a/src/findTarget.js
+++ b/src/findTarget.js
@@ -11,9 +11,12 @@
         return inEl.shadowRoot || inEl.webkitShadowRoot;
       }
     },
+    canTarget: function(scope) {
+      return scope && Boolean(scope.elementFromPoint);
+    },
     targetingShadow: function(inEl) {
       var s = this.shadow(inEl);
-      if (s && s.elementFromPoint) {
+      if (this.canTarget(s)) {
         return s;
       }
     },

--- a/src/installer.js
+++ b/src/installer.js
@@ -29,7 +29,16 @@
       attributeFilter: ['touch-action']
     },
     watchSubtree: function(inScope) {
-      observer.observe(inScope, this.OBSERVER_INIT);
+      // Only watch scopes that can target find, as these are top-level.
+      // Otherwise we can see duplicate additions and removals that add noise.
+      //
+      // TODO(dfreedman): For some instances with ShadowDOMPolyfill, we can see
+      // a removal without an insertion when a node is redistributed among
+      // shadows. Since it all ends up correct in the document, watching only
+      // the document will yield the correct mutations to watch.
+      if (scope.targetFinding.canTarget(inScope)) {
+        observer.observe(inScope, this.OBSERVER_INIT);
+      }
     },
     enableOnSubtree: function(inScope) {
       var scope = inScope || document;


### PR DESCRIPTION
ShadowDOMPolyfill is super verbose watching fake shadow roots (to emulate redistribution), and this causes duplicate add/removeElementListener calls as things flow into and out of the document.

As the document is the "one source of truth" in the ShadowDOMPolyfill, it is the only thing that we need to watch in that instance.

Real ShadowDOM is watched correctly, because it can contain nodes the document would never see otherwise.
