### PR TITLE
Fix longpress causing bogus pointerdown

### DIFF
--- a/src/platform-events.js
+++ b/src/platform-events.js
@@ -126,6 +126,7 @@
     touchstart: function(inEvent) {
       this.vacuumTouches(inEvent);
       this.setPrimaryTouch(inEvent.changedTouches[0]);
+      this.dedupSynthMouse(inEvent);
       if (!this.scrolling) {
         this.processTouches(inEvent, this.overDown);
       }


### PR DESCRIPTION
- Use same process for touchend, but with touchstart
- Fixes #44
