### PR TITLE
allows polyfill to be installed at 'interactive' document ready state

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -50,7 +50,7 @@
     },
     enableOnSubtree: function(target) {
       this.watchSubtree(target);
-      if (target === document && document.readyState !== 'complete') {
+      if (target === document && document.readyState !== 'complete' && document.readyState !== 'interactive') {
         this.installOnLoad();
       } else {
         this.installNewSubtree(target);


### PR DESCRIPTION
In some cases document can stuck in 'interactive' state which means document is finished parsing but some resources are still being loaded https://developer.mozilla.org/en-US/docs/Web/API/document.readyState

Supporting this situation is important since there are cases where scripts are loaded dynamically so you can't rely on DOMContentLoaded event since it could be already fired
http://mail-archives.apache.org/mod_mbox/incubator-callback-commits/201206.mbox/%3C20120601235227.4EAE5F656@tyr.zones.apache.org%3E
