### PR TITLE
A few spec compliance changes to pass the w3c tests

### DIFF
--- a/src/PointerEvent.js
+++ b/src/PointerEvent.js
@@ -117,6 +117,9 @@
       );
     }
 
+    // make the event pass instanceof checks
+    e.__proto__ = PointerEvent.prototype;
+
     // define the buttons property according to DOM Level 3 spec
     if (!HAS_BUTTONS) {
       // IE 10 has buttons on MouseEvent.prototype as a getter w/o any setting
@@ -147,6 +150,9 @@
     });
     return e;
   }
+
+  // PointerEvent extends MouseEvent
+  PointerEvent.prototype = Object.create(MouseEvent.prototype);
 
   // attach to window
   if (!scope.PointerEvent) {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -215,6 +215,10 @@
      * @return {Event} A PointerEvent of type `inType`
      */
     makeEvent: function(inType, inEvent) {
+      // relatedTarget must be null if pointer is captured
+      if (this.captureInfo) {
+        inEvent.relatedTarget = null;
+      }
       var e = new PointerEvent(inType, inEvent);
       this.targets.set(e, this.targets.get(inEvent) || inEvent.target);
       return e;


### PR DESCRIPTION
- relatedTarget must be null if pointerevent is capturing
- `new PointerEvent(..) instanceof PointerEvent === true`
- Manual tests: http://github.com/w3c/web-platform-tests

Manually verified by using w3c/web-platform-tests#324 and injecting PointerEvents polyfill into each test:

``` bash
sed -i '' -e '/testharness.js"/{
a\
<script src="../../polymer/PointerEvents/pointerevents.js"></script>
}' web-platform-tests/pointerevents/*.html
```
