### PR TITLE
Fix touchEvent support for touch-action

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -15,8 +15,13 @@
   var CLICK_COUNT_TIMEOUT = 200;
   var ATTRIB = 'touch-action';
   var INSTALLER;
-  var HAS_TOUCH_ACTION_DELAY = (typeof document.head.style.touchActionDelay) === 'string';
-
+  // The presence of touch event handlers blocks scrolling, and so we must be careful to
+  // avoid adding handlers unnecessarily.  Chrome plans to add a touch-action-delay property
+  // (crbug.com/329559) to address this, and once we have that we can opt-in to a simpler
+  // handler registration mechanism.  Rather than try to predict how exactly to opt-in to
+  // that we'll just leave this disabled until there is a build of Chrome to test.
+  var HAS_TOUCH_ACTION_DELAY = false;
+  
   // handler block for native touch events
   var touchEvents = {
     scrollType: new WeakMap(),


### PR DESCRIPTION
Change HAS_TOUCH_ACTION to HAS_TOUCH_ACTION_DELAY.  Even with touch-action we should still avoid unnecessary touch handlers.  It's only with touch-action-delay: none that we can be sure our handlers won't delay threaded scrolling.

This works around #116 for now without actually solving it completely.
