### PR TITLE
Fix pointerId property

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -21,7 +21,7 @@
   // handler registration mechanism.  Rather than try to predict how exactly to opt-in to
   // that we'll just leave this disabled until there is a build of Chrome to test.
   var HAS_TOUCH_ACTION_DELAY = false;
-  
+
   // handler block for native touch events
   var touchEvents = {
     scrollType: new WeakMap(),
@@ -149,7 +149,10 @@
       // Spec specifies that pointerId 1 is reserved for Mouse.
       // Touch identifiers can start at 0.
       // Add 2 to the touch identifier for compatibility.
-      e.pointerId = inTouch.identifier + 2;
+      if (e.pointerId === 0)
+      {
+        e.pointerId = inTouch.identifier + 2;
+      }
       e.target = findTarget(e);
       e.bubbles = true;
       e.cancelable = true;


### PR DESCRIPTION
Data passed from vacuumTouches do not have identifier property but already have pointerId property.
PointerId property of event will become NaN, and can not delete in cleanUpPointer method.
