### PR TITLE
Fixed: only descendants of newly-inserted elements found

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -61,7 +61,11 @@
     },
     findElements: function(target) {
       if (target.querySelectorAll) {
-        return target.querySelectorAll(SELECTOR);
+        var result = target.querySelectorAll(SELECTOR);
+        if(target.hasAttribute && target.hasAttribute('touch-action')) { 
+          return [].concat.apply([target],result);
+        }
+      	return result;
       }
       return [];
     },


### PR DESCRIPTION
The domElement.querySelectorAll(SELECTOR) call does not include "domElement" itself in its return value, even if it matches.
