### PR TITLE
Add "main" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pepjs",
   "version": "0.3.1-pre",
+  "main": "dist/pep.js",
   "description": "Polyfill of the PointerEvents W3C spec",
   "author": {
     "name": "jQuery Foundation and other contributors",


### PR DESCRIPTION
This allows users of bundlers like browserify and webpack to simply `require('pep.js')` to get the `dist` build after installing PEP from npm.

Also if "grunt" is added as a prepublish step in the scripts field, it will be run and generate `dist` right before pep is published. Let me know if you'd like that.