### PR TITLE
Fixed Firefox "Argument 1 of Node.contains does not implement interfa…

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -145,7 +145,12 @@ var dispatcher = {
     }
   },
   contains: /*scope.external.contains || */function(container, contained) {
-    return container.contains(contained);
+    try {
+      return container.contains(contained);
+    } catch(ex) {
+      // most likely: https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+      return false;
+    }
   },
 
   // EVENTS


### PR DESCRIPTION
…ce Node"

On Firefox there is anonymous div's inside input elements. Explanation here: https://bugzilla.mozilla.org/show_bug.cgi?id=208427. If you search for "bugzilla 208427" on github you will see a lot of libraries fixing this in the same way.

Ref gh-193