### PR TITLE
Package: Explicitly list dist/ in files to include it when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "type": "git",
     "url": "git://github.com/jquery/PEP.git"
   },
+  "files": ["dist/", "src/", "pointerevents.js", "samples/"],
   "bugs": "https://github.com/jquery/PEP/issues",
   "licenses": [
     {


### PR DESCRIPTION
Fixes #223 

The `dist/` folder is listed in `.gitignore`, which npm applies for `npm-publish`. Adding a `files` array to `package.json` overrides that. It also removes everything else except LICENSE.txt, README.md and package.json, which should be fine.

Tested with `npm install @jzaefferer/pepjs@0.3.3-pre`