### PR TITLE
Handle FF Ubuntu deviation for mouseup

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -104,7 +104,10 @@ var mouseEvents = {
         inEvent.buttons = e.buttons;
       }
       pointermap.set(this.POINTER_ID, inEvent);
-      if (e.buttons === 0) {
+
+      // FF Ubuntu includes the lifted button in the `buttons` property on
+      // mouseup.
+      if (e.buttons === 0 || e.buttons === BUTTON_TO_BUTTONS[e.button]) {
         this.cleanupMouse();
         dispatcher.up(e);
       } else {


### PR DESCRIPTION
Tackles #242.

Not sure if you'd rather want to wait for a response from FF. I believe this PR should not break the current behaviour (incl. chorded button presses), while fixing the situation for Ubuntu FF.

- `button` says which button triggers the `mouseup`
- `buttons` says which buttons (in summation) are used

Cases:
- If `buttons` includes the lifted button's value:
    - `buttons === BUTTON_TO_BUTTONS[button]`:
        - The triggering button is the last one in use and afterwards no buttons are pressed anymore
    - `buttons !== BUTTON_TO_BUTTONS[button]`:
        - The triggering button is not the last active button
- If `buttons` does not include the lifted button's value:
    - `buttons === BUTTON_TO_BUTTONS[button]`:
        - Not possible: The triggering button's value is by definition not part of `buttons`. Every possible value of `buttons` uniquely identifies one specific state (bitmap). Thus no other combination of buttons can cause the `buttons` value.
    - `buttons !== BUTTON_TO_BUTTONS[button]`:
        - Not relevant

I hope these cases are sound.