### PR TITLE
Set button property to -1 if no mouse button is depressed.

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -87,6 +87,7 @@ var mouseEvents = {
     if (!this.isEventSimulatedFromTouch(inEvent)) {
       var e = this.prepareEvent(inEvent);
       if (!HAS_BUTTONS) { this.prepareButtonsForMove(e, inEvent); }
+      e.button = -1;
       dispatcher.move(e);
     }
   },
@@ -109,7 +110,8 @@ var mouseEvents = {
       // FF Ubuntu includes the lifted button in the `buttons` property on
       // mouseup.
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1223366
-      if (e.buttons === 0 || e.buttons === BUTTON_TO_BUTTONS[e.button]) {
+      e.buttons &= ~BUTTON_TO_BUTTONS[e.button];
+      if (e.buttons === 0) {
         this.cleanupMouse();
         dispatcher.up(e);
       } else {
@@ -121,6 +123,7 @@ var mouseEvents = {
     if (!this.isEventSimulatedFromTouch(inEvent)) {
       var e = this.prepareEvent(inEvent);
       if (!HAS_BUTTONS) { this.prepareButtonsForMove(e, inEvent); }
+      e.button = -1;
       dispatcher.enterOver(e);
     }
   },
@@ -128,6 +131,7 @@ var mouseEvents = {
     if (!this.isEventSimulatedFromTouch(inEvent)) {
       var e = this.prepareEvent(inEvent);
       if (!HAS_BUTTONS) { this.prepareButtonsForMove(e, inEvent); }
+      e.button = -1;
       dispatcher.leaveOut(e);
     }
   },

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -27,8 +27,7 @@ define({
   ],
   functionalSuites: [
 
-    // See: https://github.com/jquery/PEP/issues/173
-    // 'tests/functional/pointerevent_button_attribute_mouse-manual',
+    'tests/functional/pointerevent_button_attribute_mouse-manual',
     'tests/functional/pointerevent_capture_mouse-manual',
     'tests/functional/pointerevent_capture_suppressing_mouse-manual',
 


### PR DESCRIPTION
Fixes #173 by setting the `button` property to `-1` if `buttons` is `0`, indicating that no button is depressed.

I couldn't find anything in the [recommendation](https://www.w3.org/TR/pointerevents/#button-states) on the expected value of `button` in events other than `pointerup` and `pointerdown`. In theory, we could add more events, in which the `button` property contains correct data: Whenever only one button is depressed, we could set the `button` value to the current depressed button by reverse-mapping `buttons`. But as this would still leave us with loads of situations, in which one cannot use the `button` property, I decided against patching it for all possible cases.
Any thoughts on that?

In addition, this PR adds to #243 as PEP now not only detects an incorrect buttons state, but also fixes it.