### PR TITLE
Dispatcher: Pointercapture events are pointer events

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -319,8 +319,7 @@ var dispatcher = {
       this.releaseCapture(inPointerId);
     }
     this.captureInfo[inPointerId] = inTarget;
-    var e = document.createEvent('Event');
-    e.initEvent('gotpointercapture', true, false);
+    var e = new PointerEvent('gotpointercapture');
     e.pointerId = inPointerId;
     this.implicitRelease = this.releaseCapture.bind(this, inPointerId);
     document.addEventListener('pointerup', this.implicitRelease);
@@ -331,8 +330,7 @@ var dispatcher = {
   releaseCapture: function(inPointerId) {
     var t = this.captureInfo[inPointerId];
     if (t) {
-      var e = document.createEvent('Event');
-      e.initEvent('lostpointercapture', true, false);
+      var e = new PointerEvent('lostpointercapture');
       e.pointerId = inPointerId;
       this.captureInfo[inPointerId] = undefined;
       document.removeEventListener('pointerup', this.implicitRelease);

--- a/tests/functional/pointerevent_gotpointercapture_before_first_pointerevent-manual.js
+++ b/tests/functional/pointerevent_gotpointercapture_before_first_pointerevent-manual.js
@@ -1,0 +1,19 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_gotpointercapture_before_first_pointerevent-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.pressMouseButton(0)
+					.releaseMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js
+++ b/tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js
@@ -1,0 +1,20 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_releasepointercapture_events_to_original_target-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.pressMouseButton(0)
+					.moveMouseTo(60, 25)
+					.releaseMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js
+++ b/tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js
@@ -1,0 +1,31 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_setpointercapture_relatedtarget-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.end()
+				.findById('target1')
+					.moveMouseTo(50, 25)
+					.end()
+				.findById('btnCapture')
+					.moveMouseTo(50, 4)
+					.pressMouseButton(0)
+					.end()
+				.findById('target1')
+					.moveMouseTo(50, 25)
+					.end()
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.releaseMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -35,7 +35,8 @@ define({
     // 'tests/functional/pointerevent_change-touch-action-onpointerdown_touch-manual',
     'tests/functional/pointerevent_constructor',
 
-    // 'tests/functional/pointerevent_gotpointercapture_before_first_pointerevent-manual',
+    'tests/functional/pointerevent_gotpointercapture_before_first_pointerevent-manual',
+
     // 'tests/functional/pointerevent_lostpointercapture_for_disconnected_node-manual',
     'tests/functional/pointerevent_lostpointercapture_is_first-manual',
 
@@ -77,9 +78,10 @@ define({
 
     'tests/functional/pointerevent_pointerup-manual.js',
     'tests/functional/pointerevent_pointerup_isprimary_same_as_pointerdown-manual.js',
-    'tests/functional/pointerevent_pointerup_pointertype-manual.js'
+    'tests/functional/pointerevent_pointerup_pointertype-manual.js',
 
-    // 'tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js',
+    'tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js',
+
     // 'tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js',
     // 'tests/functional/pointerevent_releasepointercapture_onpointercancel_touch-manual.js',
     // 'tests/functional/pointerevent_releasepointercapture_onpointerup_mouse-manual'
@@ -87,7 +89,8 @@ define({
     // 'tests/functional/pointerevent_setpointercapture_disconnected-manual.js',
     // 'tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js',
     // 'tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js',
-    // 'tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js',
+    'tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js'
+
     // 'tests/functional/pointerevent_touch-action-auto-css_touch-manual.js',
     // 'tests/functional/pointerevent_touch-action-button-test_touch-manual.js',
     // 'tests/functional/pointerevent_touch-action-illegal.js',


### PR DESCRIPTION
This PR simply creates pointer events for `gotpointercapture` and `lostpointercapture`, instead of normal events. (See #269).

The approaches mentioned in #269 either create additional overhead or may send events where some of the properties are stale. So this PR just keeps all properties of the `*pointercapture` events as default, except for the `pointerId` and `target` properties.

The objective of this PR: Three more w3c tests would pass.