### PR TITLE
Dispatcher: Handle nested pointerenter/leave

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -197,15 +197,11 @@ var dispatcher = {
   },
   leaveOut: function(event) {
     this.out(event);
-    if (!this.contains(event.target, event.relatedTarget)) {
-      this.leave(event);
-    }
+    this.propagate(event, this.leave, false);
   },
   enterOver: function(event) {
     this.over(event);
-    if (!this.contains(event.target, event.relatedTarget)) {
-      this.enter(event);
-    }
+    this.propagate(event, this.enter, true);
   },
 
   // LISTENER LOGIC
@@ -313,6 +309,21 @@ var dispatcher = {
     if (inEvent._target === capture || !(inEvent.type in BOUNDARY_EVENTS)) {
       return capture;
     }
+  },
+  propagate: function(event, fn, propagateDown) {
+    var target = event.target;
+    var targets = [];
+    while (!target.contains(event.relatedTarget) && target !== document) {
+      targets.push(target);
+      target = target.parentNode;
+    }
+    if (propagateDown) {
+      targets.reverse();
+    }
+    targets.forEach(function(target) {
+      event.target = target;
+      fn.call(this, event);
+    }, this);
   },
   setCapture: function(inPointerId, inTarget) {
     if (this.captureInfo[inPointerId]) {

--- a/src/touch.js
+++ b/src/touch.js
@@ -265,8 +265,7 @@ var touchEvents = {
       out: inPointer,
       outTarget: inPointer.target
     });
-    dispatcher.over(inPointer);
-    dispatcher.enter(inPointer);
+    dispatcher.enterOver(inPointer);
     dispatcher.down(inPointer);
   },
   touchmove: function(inEvent) {
@@ -318,8 +317,7 @@ var touchEvents = {
   upOut: function(inPointer) {
     if (!this.scrolling) {
       dispatcher.up(inPointer);
-      dispatcher.out(inPointer);
-      dispatcher.leave(inPointer);
+      dispatcher.leaveOut(inPointer);
     }
     this.cleanUpPointer(inPointer);
   },
@@ -328,8 +326,7 @@ var touchEvents = {
   },
   cancelOut: function(inPointer) {
     dispatcher.cancel(inPointer);
-    dispatcher.out(inPointer);
-    dispatcher.leave(inPointer);
+    dispatcher.leaveOut(inPointer);
     this.cleanUpPointer(inPointer);
   },
   cleanUpPointer: function(inPointer) {

--- a/tests/functional/pointerevent_pointerleave_descendants-manual.js
+++ b/tests/functional/pointerevent_pointerleave_descendants-manual.js
@@ -9,10 +9,11 @@ define(function(require) {
 		main: function() {
 			return w3cTest(this.remote, name + '.html')
 				.findById('target0')
-					.moveMouseTo(50, 8)
+					.moveMouseTo(200, 10)
 					.end()
-				.findByTagName('body')
-					.moveMouseTo(50, 30)
+				.findByCssSelector('#target0 div')
+					.moveMouseTo(200, 10)
+					.moveMouseTo(200, 150)
 					.end()
 				.checkResults();
 		}


### PR DESCRIPTION
This PR tackles the issues pointed out in https://github.com/jquery/PEP/issues/197.

For visually overlapping elements, `pointerenter` and `pointerleave` events should propagate (but not bubble), analog to the way it works for mouse events: https://www.w3.org/TR/uievents/#figure-mouse-event-stacked-elements.

As @dmethvin describes,  `pointerenter` and `pointerleave` currently only fire on the original target of the event.

Iiuc, we listen on `document` for mouse events to bubble all the way up. Since `mouseenter` and `mouseleave` do not bubble, they never reach `document` and we will never _hear_ them. Thus we create `pointerenter` and `pointerleave` based on `mouseover` and `mouseout`, respectively.

I put this on WIP, because I haven't had the chance to test it on touch devices and Linux. I intend to get to that by next week. Also, does anyone have other ideas on how to approach this?