### PR TITLE
Mouse: Mouse is always an active pointer

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -2,27 +2,37 @@ import dispatcher from 'dispatcher';
 
 var n = window.navigator;
 var s, r;
-function assertDown(id) {
+function assertActive(id) {
   if (!dispatcher.pointermap.has(id)) {
-    throw new Error('InvalidPointerId');
+    var error = new Error('InvalidPointerId');
+    error.name = 'InvalidPointerId';
+    throw error;
   }
+}
+function inActiveButtonState(id) {
+  var p = dispatcher.pointermap.get(id);
+  return p.buttons !== 0;
 }
 if (n.msPointerEnabled) {
   s = function(pointerId) {
-    assertDown(pointerId);
-    this.msSetPointerCapture(pointerId);
+    assertActive(pointerId);
+    if (inActiveButtonState(pointerId)) {
+      this.msSetPointerCapture(pointerId);
+    }
   };
   r = function(pointerId) {
-    assertDown(pointerId);
+    assertActive(pointerId);
     this.msReleasePointerCapture(pointerId);
   };
 } else {
   s = function setPointerCapture(pointerId) {
-    assertDown(pointerId);
-    dispatcher.setCapture(pointerId, this);
+    assertActive(pointerId);
+    if (inActiveButtonState(pointerId)) {
+      dispatcher.setCapture(pointerId, this);
+    }
   };
   r = function releasePointerCapture(pointerId) {
-    assertDown(pointerId);
+    assertActive(pointerId);
     dispatcher.releaseCapture(pointerId, this);
   };
 }

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -76,7 +76,7 @@ var mouseEvents = {
         inEvent.buttons = e.buttons;
       }
       pointermap.set(this.POINTER_ID, inEvent);
-      if (!p) {
+      if (!p || p.buttons === 0) {
         dispatcher.down(e);
       } else {
         dispatcher.move(e);
@@ -88,6 +88,7 @@ var mouseEvents = {
       var e = this.prepareEvent(inEvent);
       if (!HAS_BUTTONS) { this.prepareButtonsForMove(e, inEvent); }
       e.button = -1;
+      pointermap.set(this.POINTER_ID, inEvent);
       dispatcher.move(e);
     }
   },
@@ -112,7 +113,6 @@ var mouseEvents = {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1223366
       e.buttons &= ~BUTTON_TO_BUTTONS[e.button];
       if (e.buttons === 0) {
-        this.cleanupMouse();
         dispatcher.up(e);
       } else {
         dispatcher.move(e);
@@ -124,6 +124,7 @@ var mouseEvents = {
       var e = this.prepareEvent(inEvent);
       if (!HAS_BUTTONS) { this.prepareButtonsForMove(e, inEvent); }
       e.button = -1;
+      pointermap.set(this.POINTER_ID, inEvent);
       dispatcher.enterOver(e);
     }
   },
@@ -138,9 +139,9 @@ var mouseEvents = {
   cancel: function(inEvent) {
     var e = this.prepareEvent(inEvent);
     dispatcher.cancel(e);
-    this.cleanupMouse();
+    this.deactivateMouse();
   },
-  cleanupMouse: function() {
+  deactivateMouse: function() {
     pointermap.delete(this.POINTER_ID);
   }
 };

--- a/tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js
+++ b/tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js
@@ -1,0 +1,20 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_releasepointercapture_invalid_pointerid-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.pressMouseButton(0)
+					.moveMouseTo(60, 25)
+					.releaseMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js
+++ b/tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js
@@ -1,0 +1,18 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_setpointercapture_inactive_button_mouse-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.moveMouseTo(60, -25)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js
+++ b/tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js
@@ -1,0 +1,18 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_setpointercapture_invalid_pointerid-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.clickMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -81,14 +81,14 @@ define({
     'tests/functional/pointerevent_pointerup_pointertype-manual.js',
 
     'tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js',
+    'tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js',
 
-    // 'tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js',
     // 'tests/functional/pointerevent_releasepointercapture_onpointercancel_touch-manual.js',
     'tests/functional/pointerevent_releasepointercapture_onpointerup_mouse-manual',
 
     // 'tests/functional/pointerevent_setpointercapture_disconnected-manual.js',
-    // 'tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js',
-    // 'tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js',
+    'tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js',
+    'tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js',
     'tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js'
 
     // 'tests/functional/pointerevent_touch-action-auto-css_touch-manual.js',

--- a/tests/support/setup.js
+++ b/tests/support/setup.js
@@ -20,6 +20,7 @@ define([
         prep('pointer' + shortType, target, callback);
       }
       var e, type;
+      var buttons = shortType === 'down' ? 1 : 0;
       if (HAS_MS) {
         var cap = shortType.slice(0, 1).toUpperCase() + shortType.slice(1);
         type = 'MSPointer' + cap;
@@ -30,11 +31,11 @@ define([
         );
       } else {
         type = 'mouse' + shortType;
-        e = document.createEvent('MouseEvent');
-        e.initMouseEvent(
-          type, true, true, null, null, 0, 0, 0, 0, false, false,
-          false, false, 0, null
-        );
+        e = new MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          buttons: buttons
+        });
       }
       target.dispatchEvent(e);
     }


### PR DESCRIPTION
This PR tackles #275 by expanding the capture logic to differentiate between active pointers and the active button state.

The `pointermap`, which keeps track of active pointers, stores the most recent mouse event, which allows for tracking the state of the mouse more closely. 
This also reduces the issue of #279, by using the `buttons` property of the latest mouse event (likely a `mousemove` event) to determine if any mouse buttons are currently pressed. The issue of #279 will remain for browsers without the `MouseEvent.buttons` property, like Safari.

Last but not least, we get to pass three more W3C tests.