### PR TITLE
Capture: Assert node is connected

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -9,6 +9,13 @@ function assertActive(id) {
     throw error;
   }
 }
+function assertConnected(elem) {
+  if (!elem.ownerDocument.contains(elem)) {
+    var error = new Error('InvalidStateError');
+    error.name = 'InvalidStateError';
+    throw error;
+  }
+}
 function inActiveButtonState(id) {
   var p = dispatcher.pointermap.get(id);
   return p.buttons !== 0;
@@ -16,6 +23,7 @@ function inActiveButtonState(id) {
 if (n.msPointerEnabled) {
   s = function(pointerId) {
     assertActive(pointerId);
+    assertConnected(this);
     if (inActiveButtonState(pointerId)) {
       this.msSetPointerCapture(pointerId);
     }
@@ -27,6 +35,7 @@ if (n.msPointerEnabled) {
 } else {
   s = function setPointerCapture(pointerId) {
     assertActive(pointerId);
+    assertConnected(this);
     if (inActiveButtonState(pointerId)) {
       dispatcher.setCapture(pointerId, this);
     }

--- a/tests/functional/pointerevent_setpointercapture_disconnected-manual.js
+++ b/tests/functional/pointerevent_setpointercapture_disconnected-manual.js
@@ -1,0 +1,18 @@
+define(function(require) {
+	var registerSuite = require('intern!object');
+	var w3cTest = require('../support/w3cTest');
+	var name = 'pointerevent_setpointercapture_disconnected-manual';
+
+	registerSuite({
+		name: name,
+
+		main: function() {
+			return w3cTest(this.remote, name + '.html')
+				.findById('target0')
+					.moveMouseTo(50, 25)
+					.clickMouseButton(0)
+					.end()
+				.checkResults();
+		}
+	});
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -86,7 +86,7 @@ define({
     // 'tests/functional/pointerevent_releasepointercapture_onpointercancel_touch-manual.js',
     'tests/functional/pointerevent_releasepointercapture_onpointerup_mouse-manual',
 
-    // 'tests/functional/pointerevent_setpointercapture_disconnected-manual.js',
+    'tests/functional/pointerevent_setpointercapture_disconnected-manual.js',
     'tests/functional/pointerevent_setpointercapture_inactive_button_mouse-manual.js',
     'tests/functional/pointerevent_setpointercapture_invalid_pointerid-manual.js',
     'tests/functional/pointerevent_setpointercapture_relatedtarget-manual.js'


### PR DESCRIPTION
This PR relies on #282. 

It adds the assertion that a node can only be the target of `setPointerCapture()`, if it is connected to the DOM. If the node is not a member of the DOM, an exception is thrown.