### PR TITLE
Mouse: Recover after out of document mouseup

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -63,7 +63,13 @@ var mouseEvents = {
   },
   prepareButtonsForMove: function(e, inEvent) {
     var p = pointermap.get(this.POINTER_ID);
-    e.buttons = p ? p.buttons : 0;
+
+    // Update buttons state after possible out-of-document mouseup.
+    if (inEvent.which === 0 || !p) {
+      e.buttons = 0;
+    } else {
+      e.buttons = p.buttons;
+    }
     inEvent.buttons = e.buttons;
   },
   mousedown: function(inEvent) {


### PR DESCRIPTION
This PR should resolve #279 for Safari.

Since we have no way of detecting the release of a pressed mouse button that occurs outside of the document, we synchronize our internal buttons state (which is stored in the `pointermap`) with the buttons state during any mouse event (e.g. a `mousemove`).

Since Safari does not have a `buttons` property, we cannot synchronize the buttons state directly. Safari does tell us via the `which` property whether any button is actually pressed during a `mousemove`, `-enter`, `-leave`, `-over` and `-out`.
If the `which` property is equal to zero, no mouse buttons are currently pressed and the `buttons` property of the pointer event should be equal to zero.
While we would not be able to detect if a chorded button press has been partially released outside of the document, this should cover the more common case of releasing a single button press outside of the document.