### PR TITLE
Tests: Fix W3C tests downloader

### DIFF
--- a/tests/support/pretest.js
+++ b/tests/support/pretest.js
@@ -62,21 +62,21 @@ function parseRepoString(string) {
 
 function getRaw(entry) {
 	return request.getAsync(options.raw(entry)).then(
-		function(res) { return _.result(res, 1); },
+		function(res) { return _.result(res, 'body'); },
 		function(err) { throw err; }
 	);
 }
 
 function getTree(entry) {
 	return request.getAsync(options.tree(entry)).then(
-		function(res) { return _.result(res, '[1].tree'); },
+		function(res) { return _.result(res, 'body.tree'); },
 		function(err) { throw err; }
 	);
 }
 
 function getFiles(tree) {
-	var pe = _.find(tree, 'path', 'pointerevents'),
-		resources = _.find(tree, 'path', 'resources');
+	var pe = _.find(tree, { path: 'pointerevents' }),
+		resources = _.find(tree, { path: 'resources' });
 
 	return Promise.all([
 		getTree(pe.url)
@@ -97,7 +97,7 @@ function getTests(tree) {
 
 function getHarness(tree) {
 	return Promise.all(_.map(harnessFiles, function(hf) {
-		var object = _.find(tree, 'path', hf),
+		var object = _.find(tree, { path: hf }),
 			$raw = getRaw(object.url);
 
 		return $raw.then(function(raw) {


### PR DESCRIPTION
After deleting the W3C tests folder, running `grunt test`, the `pretest` fails to download the W3C tests suite.

See a recent Travis build: https://travis-ci.org/jquery/PEP/builds/138478629