### PR TITLE
Touch: Use touch-action and passive event listeners if supported

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,5 +1,7 @@
 import PointerEvent from './PointerEvent';
 import PointerMap from './pointermap';
+import {touchActionSupported} from './feature-detect';
+import {passiveEventListenerSupported} from './feature-detect';
 
 var CLONE_PROPS = [
 
@@ -235,7 +237,9 @@ var dispatcher = {
     }, this);
   },
   addEvent: /*scope.external.addEvent || */function(target, eventName) {
-    target.addEventListener(eventName, this.boundHandler);
+    var passiveListener = passiveEventListenerSupported && touchActionSupported;
+    var passiveOrCapture = passiveListener ? { passive: true } : false;
+    target.addEventListener(eventName, this.boundHandler, passiveOrCapture);
   },
   removeEvent: /*scope.external.removeEvent || */function(target, eventName) {
     target.removeEventListener(eventName, this.boundHandler);

--- a/src/feature-detect.js
+++ b/src/feature-detect.js
@@ -1,0 +1,27 @@
+var touchActionValues = ['none', 'auto', 'pan-x', 'pan-y', 'manipulation'];
+
+function hasTouchActionSupport() {
+  var div = document.createElement('div');
+  return touchActionValues.reduce(function(supported, value) {
+    div.style.setProperty('touch-action', value);
+    var isSet = div.style.getPropertyValue('touch-action') === value;
+    return supported && isSet;
+  }, true);
+}
+
+function hasPassiveEventListenerSupport() {
+  var supported = false;
+  try {
+    addEventListener("test", null, Object.defineProperty({}, 'passive', {
+      get: function() {
+        supported = true;
+      }
+    }));
+  } catch (e) {}
+  return supported;
+}
+
+var passiveEventListenerSupported = hasPassiveEventListenerSupport();
+var touchActionSupported = hasTouchActionSupport();
+
+export {passiveEventListenerSupported, touchActionSupported};

--- a/src/touch-action.js
+++ b/src/touch-action.js
@@ -1,3 +1,5 @@
+import {touchActionSupported} from './feature-detect';
+
 function shadowSelector(v) {
   return 'body /shadow-deep/ ' + selector(v);
 }
@@ -22,14 +24,11 @@ var attrib2css = [
 ];
 var styles = '';
 
-// only install stylesheet if the browser has touch action support
-var hasNativePE = window.PointerEvent || window.MSPointerEvent;
-
 // only add shadow selectors if shadowdom is supported
 var hasShadowRoot = !window.ShadowDOMPolyfill && document.head.createShadowRoot;
 
 export function applyAttributeStyles() {
-  if (hasNativePE) {
+  if (touchActionSupported) {
     attrib2css.forEach(function(r) {
       if (String(r) === r) {
         styles += selector(r) + rule(r) + '\n';


### PR DESCRIPTION
This PR aims at using native `touch-action` and passive event listeners (#278), if the browser supports them.

If `touch-action` is supported, we can apply the matching `touch-action` style to the elements with the `touch-action` attribute. We would also no longer need to `preventDefault()` any touch events, since we only had to do it to mimic the behaviour of `touch-action`.

Iiuc, with touch-action and passive event listener support we can use the code originally meant for `touch-action-delay` (https://github.com/jquery/PEP/blob/master/src/touch.js#L17-L22). In https://crbug.com/347272 `touch-action-delay` has been dropped in favour of passive event listeners.

With touch-action and passive event listeners supported, the touch event listener can attach to `document`, since performance should no longer be an issue (not yet tested), and `installer.js` with the `MutationObserver` won't be needed anymore. We still need to be able to detect if at any point during a touch gesture some default user agent behaviour takes over (I hope I got this part correct). Once default UA behaviour takes over, we need to fire a `pointercancel` and ignore subsequent `touchmove` events.
To detect default UA behaviour, I check if `touchmove` is `cancelable`. If it is cancelable, no default UA behaviour is taking place and a `pointermove` should fire. If it is not cancelable, some default UA behaviour is taking over (passive event listeners disallow canceling default UA behaviour, setting `cancelable` to `false`).

Using native `touch-action` _will_ change some of the behaviour of PEP.
E.g. the behaviour of nested elements with different `touch-action` properties will be different. PEP allows an element with `touch-action: auto` to scroll, even if it is a child of an element with `touch-action: none`. Using native `touch-action` no scrolling would be possible, see: http://bethge.github.io/touch-action/pep-touch-action.html
Also, with native touch action support, an element with `touch-action: auto` may still fire pointer events, e.g. if the user "scrolls against the wall".

I haven't checked any corner cases at this point. Just want to make sure I got in principle the expected behaviour and whether we are o.k. with different behaviours across browsers.