### PR TITLE
PointerEvent: set pressure to 0 unless pointer is down

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,5 +1,6 @@
 Authors ordered by first contribution
 
+Google, Inc.
 Daniel Freedman <dfreedm@google.com>
 Boris Smus <boris@smus.com>
 Yvonne Yip <ykyyip@google.com>
@@ -23,3 +24,6 @@ Stefan Neubert <dev@steditor.net>
 Jörn Zaefferer <joern.zaefferer@gmail.com>
 Marius Stefan Bethge <marius.bethge@gmail.com>
 Rob Larsen <rob@htmlcssjavascript.com>
+Alexander Schmitz <arschmitz@gmail.com>
+Robert Tuttle <robert.tuttle@frogdesign.com>
+Brenton Simpson <appsforartists@google.com>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,11 @@ module.exports = function(grunt) {
   var allFiles = srcFiles.concat(buildFiles).concat(testFiles);
 
   grunt.initConfig({
+    authors: {
+      prior: [
+        'Google, Inc.'
+      ]
+    },
     uglify: {
       pointerevents: {
         options: {

--- a/src/PointerEvent.js
+++ b/src/PointerEvent.js
@@ -67,7 +67,8 @@ function PointerEvent(inType, inDict) {
   // Spec requires that pointers without pressure specified use 0.5 for down
   // state and 0 for up state.
   var pressure = 0;
-  if (inDict.pressure) {
+
+  if (inDict.pressure && e.buttons) {
     pressure = inDict.pressure;
   } else {
     pressure = e.buttons ? 0.5 : 0;


### PR DESCRIPTION
Nonsensically, `pointerup` events currently have a non-zero pressure on iOS.  As outlined in https://github.com/w3c/pointerevents/issues/146, the spec should be updated to make it clear that if a pointer is up, pressure must be 0.  (This is already the case for pointers that don't report granular pressure - this proposal only makes that rule consistent.)  This PR also makes PEP's behavior consistent with Firefox on all platforms.

https://github.com/w3c/web-platform-tests also needs to be updated, both to assert that pressure is 0 in `pointerup` and to test for custom pressure in a `pointermove`; the current test checks in `pointerover`.