### PR TITLE
Touch: Remove touch-action-delay support

### DIFF
--- a/src/touch-action.js
+++ b/src/touch-action.js
@@ -5,7 +5,7 @@ function selector(v) {
   return '[touch-action="' + v + '"]';
 }
 function rule(v) {
-  return '{ -ms-touch-action: ' + v + '; touch-action: ' + v + '; touch-action-delay: none; }';
+  return '{ -ms-touch-action: ' + v + '; touch-action: ' + v + '; }';
 }
 var attrib2css = [
   'none',

--- a/src/touch.js
+++ b/src/touch.js
@@ -14,13 +14,6 @@ var CLICK_COUNT_TIMEOUT = 200;
 var ATTRIB = 'touch-action';
 var INSTALLER;
 
-// The presence of touch event handlers blocks scrolling, and so we must be careful to
-// avoid adding handlers unnecessarily.  Chrome plans to add a touch-action-delay property
-// (crbug.com/329559) to address this, and once we have that we can opt-in to a simpler
-// handler registration mechanism.  Rather than try to predict how exactly to opt-in to
-// that we'll just leave this disabled until there is a build of Chrome to test.
-var HAS_TOUCH_ACTION_DELAY = false;
-
 // handler block for native touch events
 var touchEvents = {
   events: [
@@ -30,19 +23,11 @@ var touchEvents = {
     'touchcancel'
   ],
   register: function(target) {
-    if (HAS_TOUCH_ACTION_DELAY) {
-      dispatcher.listen(target, this.events);
-    } else {
-      INSTALLER.enableOnSubtree(target);
-    }
+    INSTALLER.enableOnSubtree(target);
   },
-  unregister: function(target) {
-    if (HAS_TOUCH_ACTION_DELAY) {
-      dispatcher.unlisten(target, this.events);
-    } else {
+  unregister: function() {
 
-      // TODO(dfreedman): is it worth it to disconnect the MO?
-    }
+    // TODO(dfreedman): is it worth it to disconnect the MO?
   },
   elementAdded: function(el) {
     var a = el.getAttribute(ATTRIB);
@@ -362,9 +347,7 @@ var touchEvents = {
   }
 };
 
-if (!HAS_TOUCH_ACTION_DELAY) {
-  INSTALLER = new Installer(touchEvents.elementAdded, touchEvents.elementRemoved,
-    touchEvents.elementChanged, touchEvents);
-}
+INSTALLER = new Installer(touchEvents.elementAdded, touchEvents.elementRemoved,
+  touchEvents.elementChanged, touchEvents);
 
 export default touchEvents;


### PR DESCRIPTION
This PR removes support for the formerly planned `touch-action-delay` CSS property.

Instead of introducing `touch-action-delay`, browser vendors are implementing the `touch-action` property and passive event listeners.