### PR TITLE
Update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup": "^0.29.0"
   },
   "web-platform-tests": {
-    "repo": "w3c/web-platform-tests#c98d1ff0ea91ba1aa9a15e8ea2d70d8ede1fdc0e",
+    "repo": "w3c/web-platform-tests#d12b850c1b6200757e9e19e794d268237c548b14",
     "path": "./tests/w3c"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup": "^0.29.0"
   },
   "web-platform-tests": {
-    "repo": "w3c/web-platform-tests#d12b850c1b6200757e9e19e794d268237c548b14",
+    "repo": "w3c/web-platform-tests#c5d333c859075744b3828a2a29057ee456234cb2",
     "path": "./tests/w3c"
   },
   "scripts": {

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -80,6 +80,8 @@ define({
     'tests/functional/pointerevent_pointerup_isprimary_same_as_pointerdown-manual.js',
     'tests/functional/pointerevent_pointerup_pointertype-manual.js',
 
+    // 'tests/functional/pointerevent_properties_mouse-manual.js',
+
     'tests/functional/pointerevent_releasepointercapture_events_to_original_target-manual.js',
     'tests/functional/pointerevent_releasepointercapture_invalid_pointerid-manual.js',
 

--- a/tests/support/pretest.js
+++ b/tests/support/pretest.js
@@ -89,7 +89,7 @@ function getFiles(tree) {
 function getTests(tree) {
 	return Promise.all(_.map(tree, function(object) {
 		if (object.type === 'tree') {
-			return Promise.resolve()
+			return Promise.resolve();
 		}
 		var $raw = getRaw(object.url);
 		return $raw.then(function(raw) {

--- a/tests/support/pretest.js
+++ b/tests/support/pretest.js
@@ -88,6 +88,9 @@ function getFiles(tree) {
 
 function getTests(tree) {
 	return Promise.all(_.map(tree, function(object) {
+		if (object.type === 'tree') {
+			return Promise.resolve()
+		}
 		var $raw = getRaw(object.url);
 		return $raw.then(function(raw) {
 			return fs.outputFileAsync(path.join(testPath, object.path), raw, 'utf-8');


### PR DESCRIPTION
This is a partial fix for #314. Specifically, this fixes the problem that prevents us from updating to the latest set of tests. However, I only went as far as the commit that caused the problems with the build system. Going further requires updating tests in order to avoid increasing test failures, so I want to address that part separately.