### PR TITLE
Tests: Update Chromedriver

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
             seleniumDownloadURL: 'http://selenium-release.storage.googleapis.com',
             drivers: {
                 chrome: {
-                  version: '2.21',
+                  version: '2.25',
                   arch: process.arch,
                   baseURL: 'http://chromedriver.storage.googleapis.com'
                 },


### PR DESCRIPTION
Bumps the Chromedriver version (#318).

Removing `node_modules` and running `npm install` required.