### PR TITLE
Dispatcher: Fix event propagation for IE 10

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -313,7 +313,9 @@ var dispatcher = {
   propagate: function(event, fn, propagateDown) {
     var target = event.target;
     var targets = [];
-    while (!target.contains(event.relatedTarget) && target !== document) {
+
+    // Order of conditions due to document.contains() missing in IE.
+    while (target !== document && !target.contains(event.relatedTarget)) {
       targets.push(target);
       target = target.parentNode;
     }


### PR DESCRIPTION
This is a simple improvement for the IE 10 event propagation bug mentioned in #320.