### PR TITLE
Dispatcher: Do not propagate over removed nodes

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -318,6 +318,10 @@ var dispatcher = {
     while (target !== document && !target.contains(event.relatedTarget)) {
       targets.push(target);
       target = target.parentNode;
+      // Touch: Do not propagate if node is detached.
+      if (!target) {
+        return;
+      }
     }
     if (propagateDown) {
       targets.reverse();


### PR DESCRIPTION
Fixes #326.

As a short term fix, checking for `null` in the `propagate` function will stop the mentioned error. 

The issue only appeared for touch input, since we trigger `pointerleave` on a `touchend`. For mouse input we trigger `pointerleave` on a `mouseout`, which the browser won't fire, because the element has been removed.

Since there are multiple situations in which a touch input may trigger a `pointerleave` I went for the simple approach of fixing it in the `propagate` function.
Though, this will (wrongfully) fire a `pointerout` on the element being removed.

I have to do more testing and spec reading to figure out the whole intended sequence of events if elements are removed during events, in particular with respect to capturing events.