### PR TITLE
Fix code style violation

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -318,6 +318,7 @@ var dispatcher = {
     while (target !== document && !target.contains(event.relatedTarget)) {
       targets.push(target);
       target = target.parentNode;
+
       // Touch: Do not propagate if node is detached.
       if (!target) {
         return;


### PR DESCRIPTION
Addresses the current Travis failure
```
Running "jscs:lint" (jscs) task
requirePaddingNewLinesBeforeLineComments: Line comments must be preceded
with a blank line at src/dispatcher.js
```