### PR TITLE
PEP in IE8

### DIFF
--- a/src/PointerEvent.js
+++ b/src/PointerEvent.js
@@ -53,11 +53,17 @@ var MOUSE_DEFAULTS = [
 function PointerEvent(inType, inDict) {
   inDict = inDict || Object.create(null);
 
-  var e = new CustomEvent(inType, {
-    bubbles: inDict.bubbles || false,
-    cancelable: inDict.cancelable || false,
-    detail: inDict.detail || {}
-  });
+  var e;
+  if (document.createEvent) {
+    e = document.createEvent("CustomEvent");
+    e.initCustomEvent(inType, inDict.bubbles || false, inDict.cancelable || false, inDict.detail || {});
+  } else {
+    e = new CustomEvent(inType, {
+      bubbles: inDict.bubbles || false,
+      cancelable: inDict.cancelable || false,
+      detail: inDict.detail || {}
+    });
+  }
 
   // define inherited MouseEvent properties
   // skip bubbles and cancelable since they're set above in initEvent()

--- a/src/PointerEvent.js
+++ b/src/PointerEvent.js
@@ -53,13 +53,17 @@ var MOUSE_DEFAULTS = [
 function PointerEvent(inType, inDict) {
   inDict = inDict || Object.create(null);
 
-  var e = document.createEvent('Event');
-  e.initEvent(inType, inDict.bubbles || false, inDict.cancelable || false);
+  var e = new CustomEvent(inType, {
+    bubbles: inDict.bubbles || false,
+    cancelable: inDict.cancelable || false,
+    detail: inDict.detail || {}
+  });
 
   // define inherited MouseEvent properties
   // skip bubbles and cancelable since they're set above in initEvent()
   for (var i = 2, p; i < MOUSE_PROPS.length; i++) {
     p = MOUSE_PROPS[i];
+    if (p == "detail") { continue; }
     e[p] = inDict[p] || MOUSE_DEFAULTS[i];
   }
   e.buttons = inDict.buttons || 0;

--- a/src/capture.js
+++ b/src/capture.js
@@ -57,16 +57,8 @@ h = function hasPointerCapture(pointerId) {
 
 export function applyPolyfill() {
   if (window.Element && !Element.prototype.setPointerCapture) {
-    Object.defineProperties(Element.prototype, {
-      'setPointerCapture': {
-        value: s
-      },
-      'releasePointerCapture': {
-        value: r
-      },
-      'hasPointerCapture': {
-        value: h
-      }
-    });
+    Object.defineProperty(Element.prototype, 'setPointerCapture', { value: s });
+    Object.defineProperty(Element.prototype, 'releasePointerCapture', { value: r });
+    Object.defineProperty(Element.prototype, 'hasPointerCapture', { value: h });
   }
 }

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -148,7 +148,7 @@ var mouseEvents = {
     this.deactivateMouse();
   },
   deactivateMouse: function() {
-    pointermap.delete(this.POINTER_ID);
+    pointermap["remove" in pointermap ? "remove" : "delete"](this.POINTER_ID);
   }
 };
 

--- a/src/ms.js
+++ b/src/ms.js
@@ -36,7 +36,7 @@ var msEvents = {
     return e;
   },
   cleanup: function(id) {
-    pointermap.delete(id);
+    pointermap["remove" in pointermap ? "remove" : "delete"](id);
   },
   MSPointerDown: function(inEvent) {
     pointermap.set(inEvent.pointerId, inEvent);

--- a/src/pointermap.js
+++ b/src/pointermap.js
@@ -12,7 +12,7 @@ function SparseArrayMap() {
 SparseArrayMap.prototype = {
   set: function(k, v) {
     if (v === undefined) {
-      return this.delete(k);
+      return this.remove(k);
     }
     if (!this.has(k)) {
       this.size++;
@@ -22,7 +22,7 @@ SparseArrayMap.prototype = {
   has: function(k) {
     return this.array[k] !== undefined;
   },
-  delete: function(k) {
+  remove: function(k) {
     if (this.has(k)) {
       delete this.array[k];
       this.size--;

--- a/src/touch.js
+++ b/src/touch.js
@@ -321,7 +321,7 @@ var touchEvents = {
     this.cleanUpPointer(inPointer);
   },
   cleanUpPointer: function(inPointer) {
-    pointermap.delete(inPointer.pointerId);
+    pointermap["remove" in pointermap ? "remove" : "delete"](inPointer.pointerId);
     this.removePrimaryPointer(inPointer);
   },
 


### PR DESCRIPTION
I was toying with PEP a bit and found out it actually works in IE9 as well. And since I have to support IE8 as well and want to use pointerevents, I wanted to try and make it work. It seems given some polyfills and with changes from this branch, it can be done.

On https://ethan.cz/hriste/pepie8/ you can try interacting with the red and yellow areas. The polyfills needed are:
document.head
Function.prototype.bind
Object.create
Array.prototype.forEach
Array.prototype.map
Array.prototype.filter
EventTarget (with CustomEvent and MouseEvent - all taken from https://github.com/ondras/ie8eventtarget)
DOMContentLoaded event