### PR TITLE
Prevent error in propagate if target is null.

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -315,7 +315,7 @@ var dispatcher = {
     var targets = [];
 
     // Order of conditions due to document.contains() missing in IE.
-    while (target !== document && !target.contains(event.relatedTarget)) {
+    while (target != null && target !== document && !target.contains(event.relatedTarget)) {
       targets.push(target);
       target = target.parentNode;
 


### PR DESCRIPTION
Partial fix for https://github.com/jquery/PEP/issues/355.

I'm still not sure how `target` can be null, but at least this prevents the error when it happens.