### PR TITLE
Document lack of capturing phase support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Run time changes involving the `touch-action` attribute are monitored using Muta
 
 Touches will not generate events unless inside of an area that has a valid `touch-action` attribute defined. This is to maintain composition scrolling optimizations where possible.
 
+### Capturing Phase
+
+PEP does not currently polyfill the capturing phase for pointer events.
+
 ## navigator.maxTouchPoints
 
 As the information necessary to populate [`navigator.maxTouchPoints`](https://www.w3.org/TR/pointerevents/#extensions-to-the-navigator-interface) is not available in browsers that do not natively implement pointer events, PEP sets the value to `0`, which is "the minimum number guaranteed to be recognized" as required by the specification.


### PR DESCRIPTION
Per [this comment](https://github.com/jquery/PEP/issues/165#issuecomment-76973625), it seems there are no plans to support the capturing phase.

I received a request to support the capturing phase of pointer events on the `<Pointable>` React component I maintain, and had to do some digging before finding out PEP doesn't support it. Hopefully elevating this fact to the readme is useful for someone else 🙂