### PR TITLE
Touch: keep firing pointer events after element removal

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -44,8 +44,19 @@ var touchEvents = {
     }
   },
   elementRemoved: function(el) {
-    el._scrollType = undefined;
-    dispatcher.unlisten(el, this.events);
+
+    // In some cases, an element is removed before a touchend.
+    // When this is the case, we should wait for the touchend before unlistening,
+    // because we still want pointer events to bubble up after removing from DOM.
+    if (pointermap.size > 0) {
+      el.addEventListener('touchend', () => {
+        el._scrollType = undefined;
+        dispatcher.unlisten(el, this.events);
+      });
+    } else {
+      el._scrollType = undefined;
+      dispatcher.unlisten(el, this.events);
+    }
 
     // remove touch-action from shadow
     allShadows(el).forEach(function(s) {


### PR DESCRIPTION
According to [the docs](https://developer.mozilla.org/en-US/docs/Web/API/Touch/target), touch events are still dispatched when the element is removed: 

> If the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore. If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.

For pointer events, we need those events to correctly propagate them so that you still receive pointer events when an element is removed during a drag (touch) operation.

See https://stackoverflow.com/questions/33298828/touch-move-event-dont-fire-after-touch-start-target-is-removed.

Closes https://github.com/jquery/PEP/issues/367.