### PR TITLE
Add support for level 2 pan keywords

### DIFF
--- a/src/touch-action.js
+++ b/src/touch-action.js
@@ -1,24 +1,18 @@
-function shadowSelector(v) {
-  return 'body /shadow-deep/ ' + selector(v);
-}
-function selector(v) {
-  return '[touch-action="' + v + '"]';
+function shadowSelector(s) {
+  return 'body /shadow-deep/ ' + s
 }
 function rule(v) {
   return '{ -ms-touch-action: ' + v + '; touch-action: ' + v + '; }';
 }
 var attrib2css = [
-  'none',
-  'auto',
-  'pan-x',
-  'pan-y',
-  {
-    rule: 'pan-x pan-y',
-    selectors: [
-      'pan-x pan-y',
-      'pan-y pan-x'
-    ]
-  }
+  { selector: '[touch-action="none"]', value: 'none' },
+  { selector: '[touch-action="auto"]', value: 'auto' },
+  { selector: '[touch-action~="pan-x"]', value: 'pan-x' },
+  { selector: '[touch-action~="pan-y"]', value: 'pan-y' },
+  { selector: '[touch-action~="pan-up"]', value: 'pan-up' },
+  { selector: '[touch-action~="pan-down"]', value: 'pan-down' },
+  { selector: '[touch-action~="pan-left"]', value: 'pan-left' },
+  { selector: '[touch-action~="pan-right"]', value: 'pan-right' }
 ];
 var styles = '';
 
@@ -31,16 +25,9 @@ var hasShadowRoot = !window.ShadowDOMPolyfill && document.head.createShadowRoot;
 export function applyAttributeStyles() {
   if (hasNativePE) {
     attrib2css.forEach(function(r) {
-      if (String(r) === r) {
-        styles += selector(r) + rule(r) + '\n';
-        if (hasShadowRoot) {
-          styles += shadowSelector(r) + rule(r) + '\n';
-        }
-      } else {
-        styles += r.selectors.map(selector) + rule(r.rule) + '\n';
-        if (hasShadowRoot) {
-          styles += r.selectors.map(shadowSelector) + rule(r.rule) + '\n';
-        }
+      styles += r.selector + rule(r.value) + '\n';
+      if (hasShadowRoot) {
+        styles += shadowSelector(r.selector) + rule(r.value) + '\n';
       }
     });
 

--- a/src/touch-action.js
+++ b/src/touch-action.js
@@ -1,5 +1,5 @@
 function shadowSelector(s) {
-  return 'body /shadow-deep/ ' + s
+  return 'body /shadow-deep/ ' + s;
 }
 function rule(v) {
   return '{ -ms-touch-action: ' + v + '; touch-action: ' + v + '; }';

--- a/src/touch.js
+++ b/src/touch.js
@@ -14,11 +14,11 @@ var CLICK_COUNT_TIMEOUT = 200;
 var ATTRIB = 'touch-action';
 var INSTALLER;
 
-// bitmask fot scroll 
-var UP = 1; // 0001
-var DOWN = 2; // 0010
-var LEFT = 4; // 0100
-var RIGHT = 8; // 1000
+// bitmask for _scrollType
+var UP = 1;
+var DOWN = 2;
+var LEFT = 4;
+var RIGHT = 8;
 var AUTO = UP | DOWN | LEFT | RIGHT;
 
 // handler block for native touch events
@@ -108,7 +108,7 @@ var touchEvents = {
     var st = this.scrollTypes;
 
     // construct a bitmask of allowed scroll directions
-    return st.UP(s) | st.DOWN(s) | st.LEFT(s) | st.RIGHT(s)
+    return st.UP(s) | st.DOWN(s) | st.LEFT(s) | st.RIGHT(s);
   },
   POINTER_TYPE: 'touch',
   firstTouch: null,
@@ -214,9 +214,9 @@ var touchEvents = {
       } else {
         var t = inEvent.changedTouches[0];
 
-        var dy = t['clientY'] - this.firstXY.Y;
+        var dy = t.clientY - this.firstXY.Y;
         var dya = Math.abs(dy);
-        var dx = t['clientX'] - this.firstXY.X;
+        var dx = t.clientX - this.firstXY.X;
         var dxa = Math.abs(dx);
 
         var up = st & UP;


### PR DESCRIPTION
This adds support for [pan-left, pan-right, pan-up, pan-down](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action#pan-keywords).

Supported values now include:

```
auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ]]
```

which is still a subset of the full spec:

```
auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation
```