### PR TITLE
Add support for 3D Touch, Force Touch, and Apple Pencil tilt

### DIFF
--- a/samples/paint/paint.js
+++ b/samples/paint/paint.js
@@ -54,6 +54,7 @@ Paint.prototype.onPointerMove = function(event) {
   // Check if there's a pointer that's down.
   if (pointer) {
     pointer.setTarget({x: event.clientX, y: event.clientY});
+    pointer.pressure = event.pressure;
     //console.log('pointers', pointer);
   }
 };
@@ -69,7 +70,7 @@ Paint.prototype.renderLoop = function(lastRender) {
     if (pointer.isDelta()) {
       //console.log('rendering', pointer.targetX);
       var ctx = this.ctx;
-      ctx.lineWidth = pointer.width;
+      ctx.lineWidth = pointer.width * (pointer.pressure || 1);
       ctx.strokeStyle = pointer.color;
       ctx.beginPath();
       ctx.moveTo(pointer.x, pointer.y);

--- a/samples/tracker/index.html
+++ b/samples/tracker/index.html
@@ -130,7 +130,7 @@ function draw() {
 }
 
 function updatePointer(e) {
-  pointers[pointerId] = {
+  pointers[e.pointerId] = {
     x: e.clientX,
     y: e.clientY,
     pointerType: e.pointerType,

--- a/samples/tracker/index.html
+++ b/samples/tracker/index.html
@@ -2,7 +2,7 @@
 <html lang=en>
   <head>
     <meta charset=utf-8>
-    <meta name="viewport" content="width=device-width; height=device-height; initial-scale=1.0; maximum-scale=1.0;" /> 
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0" />
     <title>PEP (Pointer Events Polyfill) Tracker</title>
     <style type="text/css"> 
 

--- a/samples/tracker/index.html
+++ b/samples/tracker/index.html
@@ -81,17 +81,34 @@ function init(){
 function draw() {
   c.clearRect(0,0,canvas.width, canvas.height); 
 
-  for(var pointerId in pointers)
-  {
-    var pointer = pointers[pointerId]; 
-    c.beginPath(); 
+  for(const pointerId of Object.keys(pointers)) {
+    c.beginPath();
     c.fillStyle = "white";
-    c.fillText(pointer.pointerType+ " pointerId : "+pointer.pointerId+" x:"+pointer.x+" y:"+pointer.y, pointer.x+30, pointer.y-30); 
+    const { pointerType, x, y, pressure, tiltX, tiltY} = pointers[pointerId];
+    c.fillText(`${pointerType} [${pointerId}] ${x},${y} ${pressure || '(no pressure)'} ${tiltX || '(no tilt)'} ${tiltY || ''}`, x+30, y-30);
 
     c.beginPath(); 
+    c.strokeStyle = "orange";
+    c.lineWidth = "4";
+    c.moveTo(x, y);
+    c.lineTo(
+      x + 40 * Math.sin(tiltX * Math.PI / 180),
+      y + 40 * Math.sin(tiltY * Math.PI / 180)
+    );
+    c.stroke();
+
+    if (pressure > 0) {
+      c.beginPath();
+      c.strokeStyle = "#008bff";
+      c.lineWidth = "6";
+      c.arc(x, y, 40 * pressure, 0, Math.PI * 2, true);
+      c.stroke();
+    }
+
+    c.beginPath();
     c.strokeStyle = "cyan";
     c.lineWidth = "6";
-    c.arc(pointer.x, pointer.y, 40, 0, Math.PI*2, true); 
+    c.arc(x, y, 40, 0, Math.PI*2, true);
     c.stroke();
   }
   //c.fillText("hello", 0,0); 
@@ -99,21 +116,22 @@ function draw() {
   requestAnimFrame(draw);
 }
 
-function onPointerDown(e) {
-  pointers[e.pointerId] = {
-    x: e.clientX,
-    y: e.clientY,
-    pointerType: e.pointerType,
-    pointerId: e.pointerId
+function onPointerDown({ clientX, clientY, pointerType, pointerId, pressure, tiltX, tiltY }) {
+  pointers[pointerId] = {
+    x: clientX,
+    y: clientY,
+    pointerType,
+    pointerId,
+    pressure,
+    tiltX,
+    tiltY,
   };
 }
 
 function onPointerMove(e) {
   // Prevent the browser from doing its default thing (scroll, zoom)
-  var pointer = pointers[e.pointerId];
-  if (pointer) {
-    pointer.x = e.clientX;
-    pointer.y = e.clientY;
+  if (e.pointerId in pointers) {
+    onPointerDown(e);
   }
 } 
 

--- a/samples/tracker/index.html
+++ b/samples/tracker/index.html
@@ -82,10 +82,23 @@ function draw() {
   c.clearRect(0,0,canvas.width, canvas.height); 
 
   for(const pointerId of Object.keys(pointers)) {
+    const p = pointers[pointerId];
     c.beginPath();
     c.fillStyle = "white";
-    const { pointerType, x, y, pressure, tiltX, tiltY} = pointers[pointerId];
-    c.fillText(`${pointerType} [${pointerId}] ${x},${y} ${pressure || '(no pressure)'} ${tiltX || '(no tilt)'} ${tiltY || ''}`, x+30, y-30);
+
+    const x = p.x;
+    const y = p.y;
+    const pressure = p.pressure;
+    const tiltX = p.tiltX;
+    const tiltY = p.tiltY;
+    c.fillText(
+      p.pointerType + ' [' + pointerId + '] ' +
+      x + ',' + y + ' ' +
+      (pressure || '(no pressure)') + ' ' +
+      (tiltX || '(no tilt)') + ' ' + (tiltY || ''),
+      x + 30,
+      y - 30
+    );
 
     c.beginPath(); 
     c.strokeStyle = "orange";
@@ -116,22 +129,26 @@ function draw() {
   requestAnimFrame(draw);
 }
 
-function onPointerDown({ clientX, clientY, pointerType, pointerId, pressure, tiltX, tiltY }) {
+function updatePointer(e) {
   pointers[pointerId] = {
-    x: clientX,
-    y: clientY,
-    pointerType,
-    pointerId,
-    pressure,
-    tiltX,
-    tiltY,
+    x: e.clientX,
+    y: e.clientY,
+    pointerType: e.pointerType,
+    pointerId: e.pointerId,
+    pressure: e.pressure,
+    tiltX: e.tiltX,
+    tiltY: e.tiltY,
   };
+}
+
+function onPointerDown(e) {
+  updatePointer(e);
 }
 
 function onPointerMove(e) {
   // Prevent the browser from doing its default thing (scroll, zoom)
   if (e.pointerId in pointers) {
-    onPointerDown(e);
+    updatePointer(e);
   }
 } 
 

--- a/src/PointerEvent.js
+++ b/src/PointerEvent.js
@@ -68,7 +68,7 @@ function PointerEvent(inType, inDict) {
   // state and 0 for up state.
   var pressure = 0;
 
-  if (inDict.pressure && e.buttons) {
+  if (inDict.pressure !== undefined && e.buttons) {
     pressure = inDict.pressure;
   } else {
     pressure = e.buttons ? 0.5 : 0;

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -19,6 +19,7 @@ var mouseEvents = {
   POINTER_TYPE: 'mouse',
   events: [
     'mousedown',
+    'webkitmouseforcechanged',
     'mousemove',
     'mouseup',
     'mouseover',
@@ -59,6 +60,9 @@ var mouseEvents = {
     e.pointerId = this.POINTER_ID;
     e.isPrimary = true;
     e.pointerType = this.POINTER_TYPE;
+    if ('webkitForce' in inEvent) {
+      e.pressure = inEvent.webkitForce - MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN;
+    }
     return e;
   },
   prepareButtonsForMove: function(e, inEvent) {
@@ -71,6 +75,10 @@ var mouseEvents = {
       e.buttons = p.buttons;
     }
     inEvent.buttons = e.buttons;
+  },
+  webkitmouseforcechanged: function(inEvent) {
+    // This is called when the user force presses the mouse without moving the position
+    this.mousedown(inEvent);
   },
   mousedown: function(inEvent) {
     if (!this.isEventSimulatedFromTouch(inEvent)) {

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -76,10 +76,6 @@ var mouseEvents = {
     }
     inEvent.buttons = e.buttons;
   },
-  webkitmouseforcechanged: function(inEvent) {
-    // This is called when the user force presses the mouse without moving the position
-    this.mousedown(inEvent);
-  },
   mousedown: function(inEvent) {
     if (!this.isEventSimulatedFromTouch(inEvent)) {
       var p = pointermap.get(this.POINTER_ID);
@@ -96,6 +92,11 @@ var mouseEvents = {
         dispatcher.move(e);
       }
     }
+  },
+
+  // This is called when the user force presses without moving x/y
+  webkitmouseforcechanged: function(inEvent) {
+    this.mousemove(inEvent);
   },
   mousemove: function(inEvent) {
     if (!this.isEventSimulatedFromTouch(inEvent)) {

--- a/src/touch.js
+++ b/src/touch.js
@@ -149,7 +149,7 @@ var touchEvents = {
     e.buttons = this.typeToButtons(cte.type);
     e.width = (inTouch.radiusX || inTouch.webkitRadiusX || 0) * 2;
     e.height = (inTouch.radiusY || inTouch.webkitRadiusY || 0) * 2;
-    e.pressure = inTouch.force || inTouch.webkitForce || 0.5;
+    e.pressure = inTouch.force !== undefined ? inTouch.force : inTouch.webkitForce !== undefined ? inTouch.webkitForce : undefined;
     e.isPrimary = this.isPrimaryTouch(inTouch);
     if (inTouch.altitudeAngle) {
       const tan = Math.tan(inTouch.altitudeAngle);

--- a/src/touch.js
+++ b/src/touch.js
@@ -149,7 +149,10 @@ var touchEvents = {
     e.buttons = this.typeToButtons(cte.type);
     e.width = (inTouch.radiusX || inTouch.webkitRadiusX || 0) * 2;
     e.height = (inTouch.radiusY || inTouch.webkitRadiusY || 0) * 2;
-    e.pressure = inTouch.force !== undefined ? inTouch.force : inTouch.webkitForce !== undefined ? inTouch.webkitForce : undefined;
+    e.pressure = inTouch.force !== undefined ?
+      inTouch.force :
+      inTouch.webkitForce !== undefined ?
+        inTouch.webkitForce : undefined;
     e.isPrimary = this.isPrimaryTouch(inTouch);
     if (inTouch.altitudeAngle) {
       const tan = Math.tan(inTouch.altitudeAngle);

--- a/src/touch.js
+++ b/src/touch.js
@@ -273,8 +273,9 @@ var touchEvents = {
     dispatcher.enterOver(inPointer);
     dispatcher.down(inPointer);
   },
+
+  // Called when pressure or tilt changes without the x/y changing
   touchforcechange: function(inEvent) {
-    // Handle pressure and tilt updates without touch point moving
     this.touchmove(inEvent);
   },
   touchmove: function(inEvent) {


### PR DESCRIPTION
## What

- add continuous pressure info when using Force Trackpads (in Safari)
- add continuous pressure info when using 3D Touch on Mobile Safari
- add tiltX/tiltY info when using Apple Pencil (on iPad) (fixes #342)
- set pointerType correctly when using Apple Pencil
- update paint sample app to render pressure
- update tracker sample app to render pressure and tilt
- fix handling of events when force is 0 (previously setting pressure to 0.5)

## Notes
- I'm new to Pointer Events, so there might be misunderstandings
- When I ran `npm test` everything failed with `unknown error: call function result missing 'value'`