### PR TITLE
Do not preventDefault on touchforcechange

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -332,7 +332,9 @@ var touchEvents = {
         this.scrolling = true;
         this.touchcancel(inEvent);
       } else {
-        inEvent.preventDefault();
+        if (inEvent.type !== 'touchforcechange') {
+          inEvent.preventDefault();
+        }
         this.processTouches(inEvent, this.moveOverOut);
       }
     }


### PR DESCRIPTION
This pull request fixes an issue on iPhones with touch force support: preventing default on `touchforcechange` events causes `click` events on parent elements to not get triggered any more.